### PR TITLE
Bugfix for unset locationCode & retailNetworkId when selecting Early Delivery

### DIFF
--- a/app/code/community/TIG/PostNL/controllers/DeliveryOptionsController.php
+++ b/app/code/community/TIG/PostNL/controllers/DeliveryOptionsController.php
@@ -917,7 +917,7 @@ class TIG_PostNL_DeliveryOptionsController extends Mage_Core_Controller_Front_Ac
             return $data;
         }
 
-        if ($type == 'PG') {
+        if (($type == 'PG') || ($type == 'PGE')) {
             if (empty($params['locationCode']) || empty($params['retailNetworkId'])) {
                 throw new TIG_PostNL_Exception(
                     $this->__('Location Code and Retail Network ID are required for post office locations.'),


### PR DESCRIPTION
A little advice, set your error level a little stricter to include NOTICE level errors:

```php
error_reporting(E_ERROR | E_WARNING | E_PARSE | E_NOTICE);
```

This setting would have brought this issue to light. The `locationCode` & `retailNetworkId` lacked in the `$data` used on line **309**:
```php
$this->getService()->saveDeliveryOption($data);
```
.. throwing a `Notice` if error reporting included that, else it just goes by unnoticed (pun intended).

These values (locationCode & retailNetworkId) need to also be taken from the request for PGE typed delivery options and added to the data that's saved.