### PR TITLE
Suggestion to change logic for qty

### DIFF
--- a/app/code/community/TIG/PostNL/Helper/Data.php
+++ b/app/code/community/TIG/PostNL/Helper/Data.php
@@ -1390,19 +1390,17 @@ class TIG_PostNL_Helper_Data extends Mage_Core_Helper_Abstract
              * Get either the qty ordered or the qty shipped, depending on whether this is an order or a shipment item.
              */
             if ($item instanceof Mage_Sales_Model_Order_Item) {
-                if ($item->getParentItemId()) {
+                $qty = $item->getQtyOrdered();
+                if (empty($qty) && $item->getParentItemId()) {
                     $qty = $item->getParentItem()->getQtyOrdered();
-                } else {
-                    $qty = $item->getQtyOrdered();
                 }
             } elseif ($item instanceof Mage_Sales_Model_Order_Shipment_Item) {
                 $qty = $item->getQty();
             } elseif($item instanceof Mage_Sales_Model_Quote_Item) {
-                if ($item->getParentItemId()) {
+                $qty = $item->getQty();
+                if (empty($qty) && $item->getParentItemId()) {
                     /** @noinspection PhpUndefinedMethodInspection */
                     $qty = $item->getParentItem()->getQty();
-                } else {
-                    $qty = $item->getQty();
                 }
             } else {
                 if ($registerReason) {


### PR DESCRIPTION
Suggestion to change logic for qty
Later on postnl_max_qty_for_buspakje is used from the simple level, it does not seem correct to validate
qty from parent <> child postnl_max_qty_for_buspakje
but rather
qty from child <> child postnl_max_qty_for_buspakje
and add fallback to parent

please test extensively

### Submitting issues trough Github
## Please follow the guide below

- You will be asked some questions and requested to provide some information, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *issue* (like this: `[x]`)
- Use the *Preview* tab to see what your issue will actually look like

---

### Make sure you are using the *latest* version: https://tig.nl/postnl-magento-extensies/
Issues with outdated version will be rejected.
- [x] I've **verified** and **I assure** that I'm running the latest version of the TIG PostNL Magento extension.

---

### What is the purpose of your *issue*?
- [x] Bug report (encountered problems with the TIG PostNL Magento extension)
- [ ] Site support request (request for adding support for a new site)
- [ ] Feature request (request for a new functionality)
- [ ] Question
- [ ] Other

---

### Description of your *issue*, suggested solution and other information

Explanation of your *issue* in arbitrary form goes here. Please make sure the [description is worded well enough to be understood]. Provide as much context and examples as possible.
If work on your *issue* requires account credentials please provide them or explain how one can obtain them.

### TIG supportdesk

On Github we will respond in English even when the question was asked in Dutch.
