### PR TITLE
Add additional PostNL order data to order API

### DIFF
--- a/app/code/community/TIG/PostNL/Model/Order/Api.php
+++ b/app/code/community/TIG/PostNL/Model/Order/Api.php
@@ -49,25 +49,38 @@ class TIG_PostNL_Model_Order_Api extends Mage_Sales_Model_Order_Api
             return $result;
         }
 
-        $pakjeGemakAddress = $postnlOrder->getPakjeGemakAddress();
-        if (!$pakjeGemakAddress) {
-            return $result;
+        if ($postnlOrder->hasPakjeGemakAddress())  {
+            $pakjeGemakAddress = $postnlOrder->getPakjeGemakAddress()->getData();
+            $pakjeGemakAddressId = array_shift($pakjeGemakAddress);
+            $pakjeGemakAddress['address_id'] = $pakjeGemakAddressId;
+
+            if ($postnlOrder->hasPgLocationCode()) {
+                $pakjeGemakAddress['location_code'] = $postnlOrder->getPgLocationCode();
+            }
+
+            if ($postnlOrder->hasPgRetailNetworkId()) {
+                $pakjeGemakAddress['retail_network_id'] = $postnlOrder->getPgRetailNetworkId();
+            }
+
+            $result['pakjegemak_address_id'] = $pakjeGemakAddressId;
+            $result['pakjegemak_address'] = $pakjeGemakAddress;
         }
 
-        $pakjeGemakAddress = $pakjeGemakAddress->getData();
-        $result['pakjegemak_address_id'] = array_shift($pakjeGemakAddress);
-
-        $pakjeGemakAddress['address_id'] = $result['pakjegemak_address_id'];
-
-        if ($postnlOrder->hasPgLocationCode()) {
-            $pakjeGemakAddress['location_code'] = $postnlOrder->getPgLocationCode();
+        if ($type = $postnlOrder->getType()) {
+            $result['postnl_type'] = $type;
         }
 
-        if ($postnlOrder->hasPgRetailNetworkId()) {
-            $pakjeGemakAddress['retail_network_id'] = $postnlOrder->getPgRetailNetworkId();
+        if ($type = $postnlOrder->hasDeliveryDate()) {
+            $result['postnl_delivery_date'] = $postnlOrder->getDeliveryDate();
         }
 
-        $result['pakjegemak_address'] = $pakjeGemakAddress;
+        if ($type = $postnlOrder->hasExpectedDeliveryTimeStart()) {
+            $result['postnl_expected_delivery_time_start'] = $postnlOrder->getExpectedDeliveryTimeStart();
+        }
+
+        if ($type = $postnlOrder->hasExpectedDeliveryTimeEnd()) {
+            $result['postnl_expected_delivery_time_end'] = $postnlOrder->getExpectedDeliveryTimeEnd();
+        }
 
         return $result;
     }


### PR DESCRIPTION
### Submitting issues trough Github
## Please follow the guide below

- You will be asked some questions and requested to provide some information, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *issue* (like this: `[x]`)
- Use the *Preview* tab to see what your issue will actually look like

---

### Make sure you are using the *latest* version: https://tig.nl/postnl-magento-extensies/
Issues with outdated version will be rejected.
- [x] I've **verified** and **I assure** that I'm running the latest version of the TIG PostNL Magento extension.

---

### What is the purpose of your *issue*?
- [ ] Bug report (encountered problems with the TIG PostNL Magento extension)
- [ ] Site support request (request for adding support for a new site)
- [x] Feature request (request for a new functionality)
- [ ] Question
- [ ] Other

---

### Description of your *issue*, suggested solution and other information

I'd like to add the following additional PostNL data to be available through the Magento1 Order API:

- Order type
- Order delivery date
- Order expected delivery time start
- Order expected delivery time end

Please see pull request. Thanks!

### Support TIG

On Github we will respond in English even when the question was asked in Dutch.
