### PR TITLE
Handle magic_quotes_runtime deprecations and removal in newer PHP versions

### DIFF
--- a/lib/TIG/PostNL/Fpdf/fpdf.php
+++ b/lib/TIG/PostNL/Fpdf/fpdf.php
@@ -1067,9 +1067,14 @@ function _dochecks()
 	// Check mbstring overloading
 	if(ini_get('mbstring.func_overload') & 2)
 		$this->Error('mbstring overloading must be disabled');
-	// Ensure runtime magic quotes are disabled
-	if(get_magic_quotes_runtime())
-		@set_magic_quotes_runtime(0);
+    // Ensure runtime magic quotes are disabled
+	if(function_exists('get_magic_quotes_runtime'))	{
+		if(@get_magic_quotes_runtime())	{
+			if(function_exists('set_magic_quotes_runtime')) {
+				@set_magic_quotes_runtime(0);
+			}
+		}
+	}
 }
 
 function _checkoutput()


### PR DESCRIPTION
This PR resolves issues regarding the deprecation and removal of `magic_quotes_runtime` functions.

Changes:
- The `get_` and `set_` functions are only called when they exist
- The `@` operator is applied to `get_` function to suppress deprecation notices (this was already done for the `set_` function)

The following was reported by the [PHP Compatibility Coding Standard for PHP_CodeSniffer](https://github.com/PHPCompatibility/PHPCompatibility) regarding the `magic_quotes_runtime` functions:

    FILE: /path/to/lib/TIG/PostNL/Fpdf/fpdf.php
    --------------------------------------------------------------------------------------------------------------------------
    FOUND 1 ERROR AND 1 WARNING AFFECTING 2 LINES
    ---------------------------------------------------------------------------------------------------------------------------
     1071 | WARNING | Function get_magic_quotes_runtime() is deprecated since PHP 7.4
     1072 | ERROR   | Function set_magic_quotes_runtime() is deprecated since PHP 5.3 and removed since PHP 7.0
    ---------------------------------------------------------------------------------------------------------------------------